### PR TITLE
Switch toX functions to tail call optimizable implementations

### DIFF
--- a/src/Lazy/List.elm
+++ b/src/Lazy/List.elm
@@ -3,7 +3,7 @@ module Lazy.List exposing (..)
 {-| Lazy list implementation in Elm.
 
 # Types
-@docs LazyList, LazyListView
+@docs LazyList, LazyListView, listHelper
 
 # Constructors
 @docs cons, empty, singleton
@@ -688,12 +688,26 @@ product5 list1 list2 list3 list4 list5 =
 -}
 toList : LazyList a -> List a
 toList list =
-    case force list of
-        Nil ->
-            []
+     List.reverse <| listHelper list []
 
-        Cons first rest ->
-            first :: toList rest
+
+{-| Helper funtion that takes advantage of tail call optimization.
+   TODO Currently, everything is exposed in this module. Is it best to start
+   explicitly naming things to expose? This isn't something that should be exposed
+   as part of this module.
+-}
+listHelper : LazyList a -> List a -> List a
+listHelper lazyList acc =
+    case (tail lazyList) of
+        Nothing ->
+            acc
+
+        Just restLazyList ->
+            case (head lazyList) of
+                Nothing ->
+                    listHelper restLazyList acc
+                Just a ->
+                    listHelper restLazyList (a :: acc)
 
 
 {-| Convert a normal list to a lazy list.


### PR DESCRIPTION
NOTE: This isn't ready to be merged in yet. Submitting this PR for
feedback before I do further work. Looking at what I have so far, are
you ok with taking this approach with all of the to* functions? We'll
also have to start naming module exports to avoid exporting the helper
function.

Currently, toList (and similar functions) are implemented recursively in
such a way that they cannot take advantage of tail call optimization.
This means that there is a hard cap on the size of collections that you
can have. For example, the following code will result in a stack
overflow with large input (100,000 on my laptop, which isn't very large).

    overflow : Int -> List Int
    overflow n =
        Lazy.List.numbers
            |> Lazy.List.take n
            |> Lazy.List.list

With this change, these implementations are switched to call out to a
helper function that is tail call optimizable. Right now, that helper
function compiles to the following JavaScript code:

    var _elm_lang$core$Random$listHelp = F4(
            function (list, n, generate, seed) {
                    listHelp:
                    while (true) {
                            if (_elm_lang$core$Native_Utils.cmp(n, 1) < 0) {
                                    return {
                                            ctor: '_Tuple2',
                                            _0: _elm_lang$core$List$reverse(list),
                                            _1: seed
                                    };
                            } else {
                                    var _p8 = generate(seed);
                                    var value = _p8._0;
                                    var newSeed = _p8._1;
                                    var _v2 = {ctor: '::', _0: value, _1: list},
                                            _v3 = n - 1,
                                            _v4 = generate,
                                            _v5 = newSeed;
                                    list = _v2;
                                    n = _v3;
                                    generate = _v4;
                                    seed = _v5;
                                    continue listHelp;
                            }
                    }
            });

With this, the size of the lists you can generate is limited only by
your hardware (and patience). In testing, this change looks to be
perform within a second of the old implementation for large input. It is
an odd comparison because the old implementation can't handle values
that are actually large, so the differences in performance is always
small.